### PR TITLE
Bugfix: Didn't pass timeout-argument to FFMPEG

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -14,6 +14,7 @@
             <argument type="collection">
                 <argument key="ffmpeg.binaries">%dubture_ffmpeg.binary%</argument>
                 <argument key="ffprobe.binaries">%dubture_ffprobe.binary%</argument>
+                <argument key="timeout">%dubture_ffmpeg.binary_timeout%</argument>
             </argument>
             <argument id="logger" type="service"/>
         </service>


### PR DESCRIPTION
This commit fixes a bug which didn't pass the timeout configuration value to the FFMPEG Service.

A Symfony-Process has a default timeout of 300 seconds, so any transcoding-operations taking longer than 300 seconds aborted with a `ProcessTimedOutException` and `ExecutionFailureException`
