### PR TITLE
Set requirement for proxy manager bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "php": "^5.3.9 || ^7.0",
         "php-ffmpeg/php-ffmpeg": "^0.5 || ^0.6",
         "symfony/dependency-injection": "^2.3 || ^3.0",
+        "symfony/proxy-manager-bridge": "^2.3 || ^3.0",
         "symfony/framework-bundle": "^2.3 || ^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
else lazy=true for the services will not be lazy and throw an error binary ffprobe not found on install.